### PR TITLE
Update TODO Feature

### DIFF
--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -1,17 +1,16 @@
 {
-	"DEFAULT_ERRORS": {
-		"INTERNAL_SERVER_ERROR": "Internal server error. Please try again later.",
-		"RESOURCE_NOT_FOUND": "Requested resource not found.",
-		"VALIDATION_FAILED": "Validation failed. Please modify the request and try again."
-	},
-	"VALIDATION_ERRORS": {
-		"INVALID_TITLE": "The title is empty or the title is not a string.",
-		"DUPLICATE_TITLE": "The title name is already taken. Please provide a different one.",
-		"INVALID_ID": "The specified ID is not a MongoDB ID.",
-		"ID_NOT_FOUND": "The item with the specified ID could not be found. Please enter a valid ID."
-	},
-	"MESSAGES": {
-		"HEALTHCHECK": "OK"
-	},
-	"Cast to string failed for value \"{ field": " 'title' }\" at path \"title\" for model \"TodoItem\""
+  "DEFAULT_ERRORS": {
+    "INTERNAL_SERVER_ERROR": "Internal server error. Please try again later.",
+    "RESOURCE_NOT_FOUND": "Requested resource not found.",
+    "VALIDATION_FAILED": "Validation failed. Please modify the request and try again."
+  },
+  "VALIDATION_ERRORS": {
+    "INVALID_TITLE": "The title is empty or the title is not a string.",
+    "DUPLICATE_TITLE": "The title name is already taken. Please provide a different one.",
+    "INVALID_ID": "The specified ID is not a MongoDB ID.",
+    "ID_NOT_FOUND": "The item with the specified ID could not be found. Please enter a valid ID."
+  },
+  "MESSAGES": {
+    "HEALTHCHECK": "OK"
+  }
 }

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -1,16 +1,17 @@
 {
-  "DEFAULT_ERRORS": {
-    "INTERNAL_SERVER_ERROR": "Internal server error. Please try again later.",
-    "RESOURCE_NOT_FOUND": "Requested resource not found.",
-    "VALIDATION_FAILED": "Validation failed. Please modify the request and try again."
-  },
-  "VALIDATION_ERRORS": {
-    "INVALID_TITLE": "The title is empty or the title is not a string.",
-    "DUPLICATE_TITLE": "The title name is already taken. Please provide a different one.",
-    "INVALID_ID": "The specified ID is not a MongoDB ID.",
-    "ID_NOT_FOUND": "The item with the specified ID could not be found. Please enter a valid ID."
-  },
-  "MESSAGES": {
-    "HEALTHCHECK": "OK"
-  }
+	"DEFAULT_ERRORS": {
+		"INTERNAL_SERVER_ERROR": "Internal server error. Please try again later.",
+		"RESOURCE_NOT_FOUND": "Requested resource not found.",
+		"VALIDATION_FAILED": "Validation failed. Please modify the request and try again."
+	},
+	"VALIDATION_ERRORS": {
+		"INVALID_TITLE": "The title is empty or the title is not a string.",
+		"DUPLICATE_TITLE": "The title name is already taken. Please provide a different one.",
+		"INVALID_ID": "The specified ID is not a MongoDB ID.",
+		"ID_NOT_FOUND": "The item with the specified ID could not be found. Please enter a valid ID."
+	},
+	"MESSAGES": {
+		"HEALTHCHECK": "OK"
+	},
+	"Cast to string failed for value \"{ field": " 'title' }\" at path \"title\" for model \"TodoItem\""
 }

--- a/src/validators/index.ts
+++ b/src/validators/index.ts
@@ -1,3 +1,4 @@
 import createTodoItemValidator from './create-todo-item-validator'
+import updateTodoItemValidator from './update-todo-item-validator'
 
-export { createTodoItemValidator }
+export { createTodoItemValidator, updateTodoItemValidator }

--- a/src/validators/update-todo-item-validator.ts
+++ b/src/validators/update-todo-item-validator.ts
@@ -1,0 +1,10 @@
+import lodash from 'lodash'
+import { check, param, ValidationChain } from 'express-validator'
+import { AppContext } from '@typings'
+
+const updateTodoItemValidator = (appContext: AppContext): ValidationChain[] => [
+  check('id', 'VALIDATION_ERRORS.INVALID_ID').isMongoId(),
+  check('title', 'VALIDATION_ERRORS.INVALID_TITLE').notEmpty().isString(),
+]
+
+export default updateTodoItemValidator

--- a/test/spec/todo-item/todo-item.spec.ts
+++ b/test/spec/todo-item/todo-item.spec.ts
@@ -90,4 +90,63 @@ describe('POST /todos', () => {
         .to.equal('The title is empty or the title is not a string.')
     }
   })
+
+  describe('PUT /todos/:id', () => {
+    it('should update a todo item if it exists, if id is valid mongo id and if title is valid non-empty string', async () => {
+      const todoitem = await testAppContext.todoItemRepository.save(
+        new TodoItem({ title: 'Update TODO' })
+      )
+
+      const res = await chai
+        .request(expressApp)
+        .put(`/todos/${todoitem._id}`)
+        .send({
+          title: 'Item Updated',
+        })
+
+      expect(res).to.have.status(200)
+      expect(res.body).to.have.property('id')
+      expect(res.body).to.have.property('title')
+    })
+
+    it('should return a validation error if empty title is specified', async () => {
+      const todoitem = await testAppContext.todoItemRepository.save(
+        new TodoItem({ title: 'TODO_TO_BE_UPDATED' })
+      )
+
+      const res = await chai
+        .request(expressApp)
+        .put(`/todos/${todoitem._id}`)
+        .send({
+          title: '',
+        })
+
+      expect(res).to.have.status(400)
+      expect(res.body)
+        .to.have.nested.property('failures[0].message')
+        .to.equal('The title is empty or the title is not a string.')
+    })
+
+    it('should return a validation error if id is invalid mongo id', async () => {
+      const res = await chai.request(expressApp).put('/todos/hhd8882nn').send({
+        title: 'Update TODO',
+      })
+
+      expect(res).to.have.status(400)
+      expect(res.body)
+        .to.have.nested.property('failures[0].message')
+        .to.equal('The specified ID is not a MongoDB ID.')
+    })
+
+    it('should return a 404 if todo item does not exists', async () => {
+      const res = await chai
+        .request(expressApp)
+        .put('/todos/605bb3efc93d78b7f4335c2c')
+        .send({
+          title: 'TODO_UPDATED',
+        })
+
+      expect(res).to.have.status(404)
+    })
+  })
 })

--- a/test/spec/todo-item/todo-item.spec.ts
+++ b/test/spec/todo-item/todo-item.spec.ts
@@ -9,6 +9,7 @@ import { respositoryContext, testAppContext } from '../../mocks/app-context'
 
 import { App } from '../../../src/server'
 import { TodoItem } from '../../../src/models'
+import { todoItems } from '../../../src/storage/mongoose'
 import lodash from 'lodash'
 
 chai.use(chaiHttp)
@@ -93,20 +94,30 @@ describe('POST /todos', () => {
 
   describe('PUT /todos/:id', () => {
     it('should update a todo item if it exists, if id is valid mongo id and if title is valid non-empty string', async () => {
-      const todoitem = await testAppContext.todoItemRepository.save(
+      const todoItem = await testAppContext.todoItemRepository.save(
         new TodoItem({ title: 'Update TODO' })
       )
 
+      const updatedItem = 'Item Updated'
+
       const res = await chai
         .request(expressApp)
-        .put(`/todos/${todoitem._id}`)
+        .put(`/todos/${todoItem._id}`)
         .send({
-          title: 'Item Updated',
+          title: updatedItem,
         })
+
+      todoItems.find({ title: updatedItem }, function (err, data) {
+        expect(new TodoItem(data[0]).serialize().title).to.deep.equal(
+          updatedItem
+        )
+      })
 
       expect(res).to.have.status(200)
       expect(res.body).to.have.property('id')
       expect(res.body).to.have.property('title')
+      expect(res.body.id).to.deep.equal(todoItem._id.toString())
+      expect(res.body.title).to.deep.equal(updatedItem)
     })
 
     it('should return a validation error if empty title is specified', async () => {


### PR DESCRIPTION
## Description
Adding a new endpoint for updating a todo item.
```
URI: PUT /todos/:id
Request body: { title: … }
Response HTTP Status: 200
Response body: { id: …, title: … }
```

## Database schema changes
NA

## Tests
### Automated test cases added
- Should update a todo item if it exists, if id is valid mongo id and if title is valid non-empty string, and return 200 status.
- Should return a validation error if empty title is specified, and return 400 status.
- Should return a validation error if id is invalid mongo id, and return 400 status.
- Should return a 404 status if todo item does not exists.

### Manual test cases run
NA