### PR TITLE
Fetch Todo item Feature

### DIFF
--- a/src/controllers/todo-item-controller.ts
+++ b/src/controllers/todo-item-controller.ts
@@ -8,7 +8,7 @@ import {
   ExtendedRequest,
   ValidationFailure,
 } from '@typings'
-import { createTodoItemValidator } from '@validators'
+import { createTodoItemValidator, fetchTodoItemValidator } from '@validators'
 
 export class TodoItemController extends BaseController {
   public basePath: string = '/todos'
@@ -24,6 +24,12 @@ export class TodoItemController extends BaseController {
       `${this.basePath}`,
       createTodoItemValidator(this.appContext),
       this.createTodoItem
+    )
+
+    this.router.get(
+      `${this.basePath}/:id`,
+      fetchTodoItemValidator(this.appContext),
+      this.fetchTodoItem
     )
   }
 
@@ -47,5 +53,35 @@ export class TodoItemController extends BaseController {
       new TodoItem({ title })
     )
     res.status(201).json(todoItem.serialize())
+  }
+
+  private fetchTodoItem = async (
+    req: ExtendedRequest,
+    res: Response,
+    next: NextFunction
+  ) => {
+    const failures: ValidationFailure[] =
+      Validation.extractValidationErrors(req)
+    if (failures.length > 0) {
+      const valError = new Errors.ValidationError(
+        res.__('DEFAULT_ERRORS.VALIDATION_FAILED'),
+        failures
+      )
+      return next(valError)
+    }
+
+    const { id } = req.params
+    const todoItem = await this.appContext.todoItemRepository.findOne({
+      _id: id,
+    })
+
+    if (todoItem._id) {
+      res.status(200).json(todoItem.serialize())
+    } else {
+      const valError = new Errors.NotFoundError(
+        res.__('DEFAULT_ERRORS.VALIDATION_FAILED')
+      )
+      next(valError)
+    }
   }
 }

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -1,17 +1,16 @@
 {
-	"DEFAULT_ERRORS": {
-		"INTERNAL_SERVER_ERROR": "Internal server error. Please try again later.",
-		"RESOURCE_NOT_FOUND": "Requested resource not found.",
-		"VALIDATION_FAILED": "Validation failed. Please modify the request and try again."
-	},
-	"VALIDATION_ERRORS": {
-		"INVALID_TITLE": "The title is empty or the title is not a string.",
-		"DUPLICATE_TITLE": "The title name is already taken. Please provide a different one.",
-		"INVALID_ID": "The specified ID is not a MongoDB ID.",
-		"ID_NOT_FOUND": "The item with the specified ID could not be found. Please enter a valid ID."
-	},
-	"MESSAGES": {
-		"HEALTHCHECK": "OK"
-	},
-	"Cast to string failed for value \"{ field": " 'title' }\" at path \"title\" for model \"TodoItem\""
+  "DEFAULT_ERRORS": {
+    "INTERNAL_SERVER_ERROR": "Internal server error. Please try again later.",
+    "RESOURCE_NOT_FOUND": "Requested resource not found.",
+    "VALIDATION_FAILED": "Validation failed. Please modify the request and try again."
+  },
+  "VALIDATION_ERRORS": {
+    "INVALID_TITLE": "The title is empty or the title is not a string.",
+    "DUPLICATE_TITLE": "The title name is already taken. Please provide a different one.",
+    "INVALID_ID": "The specified ID is not a MongoDB ID.",
+    "ID_NOT_FOUND": "The item with the specified ID could not be found. Please enter a valid ID."
+  },
+  "MESSAGES": {
+    "HEALTHCHECK": "OK"
+  }
 }

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -1,16 +1,17 @@
 {
-  "DEFAULT_ERRORS": {
-    "INTERNAL_SERVER_ERROR": "Internal server error. Please try again later.",
-    "RESOURCE_NOT_FOUND": "Requested resource not found.",
-    "VALIDATION_FAILED": "Validation failed. Please modify the request and try again."
-  },
-  "VALIDATION_ERRORS": {
-    "INVALID_TITLE": "The title is empty or the title is not a string.",
-    "DUPLICATE_TITLE": "The title name is already taken. Please provide a different one.",
-    "INVALID_ID": "The specified ID is not a MongoDB ID.",
-    "ID_NOT_FOUND": "The item with the specified ID could not be found. Please enter a valid ID."
-  },
-  "MESSAGES": {
-    "HEALTHCHECK": "OK"
-  }
+	"DEFAULT_ERRORS": {
+		"INTERNAL_SERVER_ERROR": "Internal server error. Please try again later.",
+		"RESOURCE_NOT_FOUND": "Requested resource not found.",
+		"VALIDATION_FAILED": "Validation failed. Please modify the request and try again."
+	},
+	"VALIDATION_ERRORS": {
+		"INVALID_TITLE": "The title is empty or the title is not a string.",
+		"DUPLICATE_TITLE": "The title name is already taken. Please provide a different one.",
+		"INVALID_ID": "The specified ID is not a MongoDB ID.",
+		"ID_NOT_FOUND": "The item with the specified ID could not be found. Please enter a valid ID."
+	},
+	"MESSAGES": {
+		"HEALTHCHECK": "OK"
+	},
+	"Cast to string failed for value \"{ field": " 'title' }\" at path \"title\" for model \"TodoItem\""
 }

--- a/src/validators/fetch-todo-item-validator.ts
+++ b/src/validators/fetch-todo-item-validator.ts
@@ -1,0 +1,9 @@
+import lodash from 'lodash'
+import { param, ValidationChain } from 'express-validator'
+import { AppContext } from '@typings'
+
+const fetchTodoItemValidator = (appContext: AppContext): ValidationChain[] => [
+  param('id', 'VALIDATION_ERRORS.INVALID_ID').isMongoId(),
+]
+
+export default fetchTodoItemValidator

--- a/src/validators/index.ts
+++ b/src/validators/index.ts
@@ -1,3 +1,4 @@
 import createTodoItemValidator from './create-todo-item-validator'
+import fetchTodoItemValidator from './fetch-todo-item-validator'
 
-export { createTodoItemValidator }
+export { createTodoItemValidator, fetchTodoItemValidator }

--- a/test/spec/todo-item/todo-item.spec.ts
+++ b/test/spec/todo-item/todo-item.spec.ts
@@ -94,11 +94,11 @@ describe('POST /todos', () => {
 
 describe('GET /todos/:id', () => {
   it('should fetch a todo item if it exists and if id is valid mongo id', async () => {
-    const todoitem = await testAppContext.todoItemRepository.save(
+    const todoItem = await testAppContext.todoItemRepository.save(
       new TodoItem({ title: 'Fetching an item' })
     )
 
-    const res = await chai.request(expressApp).get(`/todos/${todoitem._id}`)
+    const res = await chai.request(expressApp).get(`/todos/${todoItem._id}`)
 
     expect(res).to.have.status(200)
     expect(res.body).to.have.property('id')
@@ -120,5 +120,15 @@ describe('GET /todos/:id', () => {
       .get('/todos/605bb3efc93d78b7f4388c2c')
 
     expect(res).to.have.status(404)
+  })
+
+  it('the id mentioned in the request should be equal to the id of the todo in the database', async () => {
+    const todoItem = await testAppContext.todoItemRepository.save(
+      new TodoItem({ title: 'Check ID' })
+    )
+    const res = await chai.request(expressApp).get(`/todos/${todoItem._id}`)
+
+    expect(res).to.have.status(200)
+    expect(res.body.id).to.deep.equal(todoItem._id.toString())
   })
 })

--- a/test/spec/todo-item/todo-item.spec.ts
+++ b/test/spec/todo-item/todo-item.spec.ts
@@ -91,3 +91,34 @@ describe('POST /todos', () => {
     }
   })
 })
+
+describe('GET /todos/:id', () => {
+  it('should fetch a todo item if it exists and if id is valid mongo id', async () => {
+    const todoitem = await testAppContext.todoItemRepository.save(
+      new TodoItem({ title: 'Fetching an item' })
+    )
+
+    const res = await chai.request(expressApp).get(`/todos/${todoitem._id}`)
+
+    expect(res).to.have.status(200)
+    expect(res.body).to.have.property('id')
+    expect(res.body).to.have.property('title')
+  })
+
+  it('Should return a validation error if id is invalid mongo id', async () => {
+    const res = await chai.request(expressApp).get('/todos/jlkm129e2nk')
+
+    expect(res).to.have.status(400)
+    expect(res.body)
+      .to.have.nested.property('failures[0].message')
+      .to.equal('The specified ID is not a MongoDB ID.')
+  })
+
+  it('should return a 404 if todo item does not exists', async () => {
+    const res = await chai
+      .request(expressApp)
+      .get('/todos/605bb3efc93d78b7f4388c2c')
+
+    expect(res).to.have.status(404)
+  })
+})


### PR DESCRIPTION
## Description
Adding a new endpoint for fetching a todo item.
```
URI: GET /todos/:id
Response HTTP Status: 200
Response body: { id: …, title: … }
```

## Database schema changes
NA

## Tests
### Automated test cases added
- Should fetch a todo item if it exists and if the id is valid mongo id, and return 200 status.
- Should return a validation error if the id is invalid mongo id, and return 400 status.
- Should return a 404 status if todo item does not exist.

### Manual test cases run
NA